### PR TITLE
update api version so we can query new objects like RecentlyViewed

### DIFF
--- a/src/classes/sObjectRemote.cls-meta.xml
+++ b/src/classes/sObjectRemote.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>27.0</apiVersion>
+    <apiVersion>32.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/sObjectRemoteTEST.cls-meta.xml
+++ b/src/classes/sObjectRemoteTEST.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>27.0</apiVersion>
+    <apiVersion>32.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/components/sObjectRemote.component-meta.xml
+++ b/src/components/sObjectRemote.component-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexComponent xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>27.0</apiVersion>
+    <apiVersion>32.0</apiVersion>
     <description>Includes the necessary JavaScript files and variable names to use the sobject-remote.js library.</description>
     <label>sObjectRemote</label>
 </ApexComponent>

--- a/src/package.xml
+++ b/src/package.xml
@@ -17,5 +17,5 @@
         <members>sObjectRemote</members>
         <name>StaticResource</name>
     </types>
-    <version>27.0</version>
+    <version>32.0</version>
 </Package>

--- a/src/pages/sObjectRemoteExamples.page-meta.xml
+++ b/src/pages/sObjectRemoteExamples.page-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
-	<apiVersion>26.0</apiVersion>
+	<apiVersion>32.0</apiVersion>
 	<label>sObjectRemoteExamples</label>
 	<description></description>
 </ApexPage>


### PR DESCRIPTION
API v27 is missing sobjects like RecentlyViewed so this just bumps the meta version to allow us to query those new objects.